### PR TITLE
Feature/disable accept language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,37 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 0.3.0 (2023-03-30)
+
+### Added
+
+- SDKConfiguration may include an optional _httpHeaders_ Record<string, string> to include custom HTTP headers. For now, accepted headers are: _Accept-Language_.
+
+  Usage example:
+
+```js
+const SitumSDK = require("@situm/sdk-js");
+
+const situmSDK = new SitumSDK({
+  auth: {
+    apiKey: "MY-API-KEY",
+    email: "MY-EMAIL",
+  },
+  domain: "https://dashboard.situm.com",
+  httpHeaders: {
+    "Accept-Language": "es",
+  },
+});
+```
+
 ## 0.3.0 (2022-11-02)
 
 ### Added
+
 - Handler for fetching the current organization info (activated modules, logos, accent colors)
 
 ### Improvements
+
 - Add base domain to the poi categories icon urls. This fixes image urls pointing to wrong environment.
 
 ## 0.2.0 (2022-04-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## 0.3.0 (2023-03-30)
+## 0.4.0 (2023-03-30)
 
 ### Added
 
-- SDKConfiguration may include an optional _httpHeaders_ Record<string, string> to include custom HTTP headers. For now, accepted headers are: _Accept-Language_.
+- SDKConfiguration may include an optional _lang_ parameter to override the _Accept-Language_ HTTP header. Fallsback to "en" if no language is provided. This avoids known issues when retrieving translated entities (bad translations due to sending arbitrary Accept-Language headers).
 
   Usage example:
 
@@ -19,11 +19,11 @@ const situmSDK = new SitumSDK({
     email: "MY-EMAIL",
   },
   domain: "https://dashboard.situm.com",
-  httpHeaders: {
-    "Accept-Language": "es",
-  },
+  lang: "es",
 });
 ```
+
+Technically you could use any [standard Accept-Language values](https://www.rfc-editor.org/rfc/rfc9110.html#name-accept-encoding) but we recommend to stick to [ISO_639-1](https://en.wikipedia.org/wiki/ISO_639-1), avoiding language variants. For example, don't use "es-GB", use "es" instead.
 
 ## 0.3.0 (2022-11-02)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Situm Technologies",
   "name": "@situm/sdk-js",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A Javascript client to Situm services, supporting Node and browser.",
   "repository": "https://github.com/situmtech/situm-sdk-js",
   "main": "dist/cjs/situm-sdk.js",

--- a/src/apiBase.ts
+++ b/src/apiBase.ts
@@ -192,6 +192,7 @@ export default class ApiBase {
     let headersToReturn = {
       ...headers,
       "Content-Type": "application/json",
+      "Accept-Language": "en",
       // "X-API-CLIENT": "SitumJSSDK/" + this.configuration.version,
     } as Record<string, string>;
 

--- a/src/apiBase.ts
+++ b/src/apiBase.ts
@@ -18,7 +18,7 @@ import { parseJWT } from "./utils/jwt";
 import SitumError from "./utils/situmError";
 import { keysToCamel, keysToSnake } from "./utils/snakeCaseCamelCaseUtils";
 
-const ACCEPTED_HEADERS = ["Accept-Language"];
+const FALLBACK_LANGUAGE = "en";
 
 type Jwt = {
   expiration: number;
@@ -191,9 +191,14 @@ export default class ApiBase {
     jwt: string | null,
     headers: Record<string, string> | undefined
   ): AxiosRequestHeaders | undefined {
+    const lang = this.configuration.lang
+      ? this.configuration.lang
+      : FALLBACK_LANGUAGE;
+
     let headersToReturn = {
       ...headers,
       "Content-Type": "application/json",
+      "Accept-Language": lang,
       // "X-API-CLIENT": "SitumJSSDK/" + this.configuration.version,
     } as Record<string, string>;
 
@@ -201,22 +206,6 @@ export default class ApiBase {
       headersToReturn = {
         ...headersToReturn,
         Authorization: "Bearer " + jwt,
-      };
-    }
-
-    if (this.configuration.httpHeaders) {
-      const filteredHttpHeaders = Object.keys(
-        this.configuration.httpHeaders
-      ).reduce((acc, key) => {
-        if (ACCEPTED_HEADERS.includes(key)) {
-          acc[key] = this.configuration.httpHeaders[key];
-        }
-        return acc;
-      }, {});
-
-      headersToReturn = {
-        ...headersToReturn,
-        ...filteredHttpHeaders,
       };
     }
 

--- a/src/apiBase.ts
+++ b/src/apiBase.ts
@@ -18,6 +18,8 @@ import { parseJWT } from "./utils/jwt";
 import SitumError from "./utils/situmError";
 import { keysToCamel, keysToSnake } from "./utils/snakeCaseCamelCaseUtils";
 
+const ACCEPTED_HEADERS = ["Accept-Language"];
+
 type Jwt = {
   expiration: number;
   organizationId: UUID;
@@ -192,7 +194,6 @@ export default class ApiBase {
     let headersToReturn = {
       ...headers,
       "Content-Type": "application/json",
-      "Accept-Language": "en",
       // "X-API-CLIENT": "SitumJSSDK/" + this.configuration.version,
     } as Record<string, string>;
 
@@ -200,6 +201,22 @@ export default class ApiBase {
       headersToReturn = {
         ...headersToReturn,
         Authorization: "Bearer " + jwt,
+      };
+    }
+
+    if (this.configuration.httpHeaders) {
+      const filteredHttpHeaders = Object.keys(
+        this.configuration.httpHeaders
+      ).reduce((acc, key) => {
+        if (ACCEPTED_HEADERS.includes(key)) {
+          acc[key] = this.configuration.httpHeaders[key];
+        }
+        return acc;
+      }, {});
+
+      headersToReturn = {
+        ...headersToReturn,
+        ...filteredHttpHeaders,
       };
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export default class SitumSDK {
    */
   readonly realtime: RealtimeApi;
 
-  static readonly version = "0.1.0";
+  static readonly version = "0.4.0";
 
   /**
    * Initializes the API configuration and services exported

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,6 +42,7 @@ export type SDKConfiguration = {
   auth?: Auth;
   timeouts?: Record<string, number>;
   version?: string;
+  httpHeaders?: Record<string, string>;
 };
 
 export type SitumSubError = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,7 +42,7 @@ export type SDKConfiguration = {
   auth?: Auth;
   timeouts?: Record<string, number>;
   version?: string;
-  httpHeaders?: Record<string, string>;
+  lang?: string;
 };
 
 export type SitumSubError = {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Backwards compatible feature
- **What is the current behavior?** (You can also link to an open issue here)
Accept-Language is not set, so browser may set it to a default value. This may cause translation issues when interacting with our API.
- **What is the new behavior (if this is a feature change)?**
Accept-Language HTTP header may be set by setting the an optional SDKConfiguration named: _httpHeaders_ (Record<string, string>). For now, accepted headers are: _Accept-Language_.  Usage example:

```js
const SitumSDK = require("@situm/sdk-js");

const situmSDK = new SitumSDK({
  auth: {
    apiKey: "MY-API-KEY",
    email: "MY-EMAIL",
  },
  domain: "https://dashboard.situm.com",
  lang: "es", 
});
```
 