### PR TITLE
feat: add new compact mode to fetch less information from server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 0.7.0 (2023-XX-XX)
+
+### Fixed
+
+- Query params where not passed propertly
+
+### Added
+
+- Add new compact view support for the buildings and pois endpoints. This new view allow to save bandwidth while fetching information.
+
+
+## 0.6.1 (2023-08-18)
+
+### Improvements
+
+- Remove the email parameter in email/apikey authentication. Now you only need to specify a valid apikey.
+
+
 ## 0.5.0 (2023-05-26)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## 0.7.0 (2023-XX-XX)
+## 0.7.0 (2023-11-03)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -114,5 +114,6 @@ npm publish
 or for beta channel
 
 ```
+npm run prepare-release
 npm publish --tag beta
 ```

--- a/examples/1-authentication.ts
+++ b/examples/1-authentication.ts
@@ -21,7 +21,7 @@ const sdkWithTimeouts = new SitumSDK({
     apiKey: "YOUR_API_KEY",
   },
   timeouts: {
-    default: 100, // ms
+    default: 10000, // ms
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Situm Technologies",
   "name": "@situm/sdk-js",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A Javascript client to Situm services, supporting Node and browser.",
   "repository": "https://github.com/situmtech/situm-sdk-js",
   "main": "dist/cjs/situm-sdk.js",

--- a/src/adapters/PoiAdapter.ts
+++ b/src/adapters/PoiAdapter.ts
@@ -43,8 +43,10 @@ export function getAdapter(serverPoi: ServerPoiGet): Poi {
   if (poi.position) {
     poi["floorId"] = poi.position.floorId;
     poi["location"] = {
-      ...poi.position.georeferences,
-      ...poi.position.cartesians,
+      lat: poi.position.lat,
+      lng: poi.position.lng,
+      x: poi.position.x,
+      y: poi.position.y,
     };
 
     delete poi.position;

--- a/src/apiBase.ts
+++ b/src/apiBase.ts
@@ -11,7 +11,7 @@ import axios, {
   AxiosRequestHeaders,
   Method,
 } from "axios";
-import { stringify } from "qs";
+// import { stringify } from "qs";
 
 import { AuthBasic, SDKConfiguration, SitumErrorType, UUID } from "./types";
 import { parseJWT } from "./utils/jwt";
@@ -19,6 +19,7 @@ import SitumError from "./utils/situmError";
 import { keysToCamel, keysToSnake } from "./utils/snakeCaseCamelCaseUtils";
 
 const FALLBACK_LANGUAGE = "en";
+const DEFAULT_TIMEOUT = 0; // no timeout
 
 type Jwt = {
   expiration: number;
@@ -37,7 +38,7 @@ export type RequestInfo = {
 export default class ApiBase {
   private readonly configuration: SDKConfiguration = {
     timeouts: {
-      default: 100,
+      default: DEFAULT_TIMEOUT,
     },
     compact: false,
   };
@@ -168,7 +169,7 @@ export default class ApiBase {
       url: requestInfo.url,
       baseURL: this.configuration.domain,
       headers: this.addDefaultHeaders(jwt, requestInfo.headers),
-      params: stringify(keysToSnake(requestInfo.params)),
+      params: keysToSnake(requestInfo.params),
       data: keysToSnake(requestInfo.body),
     } as AxiosRequestConfig;
 

--- a/src/apiBase.ts
+++ b/src/apiBase.ts
@@ -35,7 +35,12 @@ export type RequestInfo = {
 };
 
 export default class ApiBase {
-  private readonly configuration: SDKConfiguration;
+  private readonly configuration: SDKConfiguration = {
+    timeouts: {
+      default: 100,
+    },
+    compact: false,
+  };
   private readonly getAuthorization;
   private jwt: string | null;
 
@@ -43,9 +48,18 @@ export default class ApiBase {
     configuration: SDKConfiguration,
     getAuthorization: () => Promise<string>
   ) {
-    this.configuration = configuration;
+    this.configuration = { ...this.configuration, ...configuration };
     this.getAuthorization = getAuthorization;
     this.jwt = null;
+  }
+
+  /**
+   * Returns the configuration of the api
+   *
+   * @returns SDKConfiguration
+   */
+  getConfiguration() {
+    return this.configuration;
   }
 
   /**

--- a/src/domains/auth.ts
+++ b/src/domains/auth.ts
@@ -10,6 +10,7 @@ import { Auth, AuthApiKey, AuthBasic } from "../types";
 
 export type AccessTokens = {
   readonly accessToken: string;
+  // readonly refreshToken: string;
 };
 
 type AuthParams =

--- a/src/domains/cartography.ts
+++ b/src/domains/cartography.ts
@@ -61,7 +61,7 @@ export default class CartographyApi {
       view?: "compact";
     } = {}
   ): Promise<readonly BuildingListElement[]> {
-    if (this.apiBase.getConfiguration().compact || params?.view == "compact") {
+    if (this.apiBase.getConfiguration().compact) {
       params.view = "compact";
     }
 
@@ -87,9 +87,10 @@ export default class CartographyApi {
     buildingId: ID,
     params: { view?: "compact" } = {}
   ): Promise<Building> {
-    if (this.apiBase.getConfiguration().compact || params?.view == "compact") {
+    if (this.apiBase.getConfiguration().compact) {
       params.view = "compact";
     }
+
     return this.apiBase
       .get<Building>({
         url: "/api/v1/buildings/" + buildingId,

--- a/src/domains/cartography.ts
+++ b/src/domains/cartography.ts
@@ -64,6 +64,7 @@ export default class CartographyApi {
     if (this.apiBase.getConfiguration().compact || params?.view == "compact") {
       params.view = "compact";
     }
+
     return this.apiBase
       .get<BuildingListElement[]>({
         url: "/api/v1/buildings",

--- a/src/domains/cartography.ts
+++ b/src/domains/cartography.ts
@@ -57,9 +57,15 @@ export default class CartographyApi {
    * @returns Promise<BuildingListElement[]>
    */
   getBuildings(): Promise<readonly BuildingListElement[]> {
+    const params: { view?: "compact" } = {};
+
+    if (this.apiBase.getConfiguration().compact) {
+      params.view = "compact";
+    }
     return this.apiBase
       .get<BuildingListElement[]>({
         url: "/api/v1/buildings",
+        params,
       })
       .then((buildingList) =>
         buildingList.map((building: Record<string, unknown>) =>
@@ -75,9 +81,15 @@ export default class CartographyApi {
    * @returns Promise<Building>
    */
   getBuildingById(buildingId: ID): Promise<Building> {
+    const params: { view?: "compact" } = {};
+
+    if (this.apiBase.getConfiguration().compact) {
+      params.view = "compact";
+    }
     return this.apiBase
       .get<Building>({
         url: "/api/v1/buildings/" + buildingId,
+        params,
       })
       .then(getBuildingAdapter);
   }
@@ -340,6 +352,10 @@ export default class CartographyApi {
       params.buildingId && params.buildingId > 0
         ? `/api/v1/buildings/${params.buildingId}/pois`
         : `/api/v1/pois`;
+
+    if (this.apiBase.getConfiguration().compact) {
+      params.view = "compact";
+    }
 
     if (params.buildingId) {
       delete params.buildingId;

--- a/src/domains/cartography.ts
+++ b/src/domains/cartography.ts
@@ -56,10 +56,12 @@ export default class CartographyApi {
    *
    * @returns Promise<BuildingListElement[]>
    */
-  getBuildings(): Promise<readonly BuildingListElement[]> {
-    const params: { view?: "compact" } = {};
-
-    if (this.apiBase.getConfiguration().compact) {
+  getBuildings(
+    params: {
+      view?: "compact";
+    } = {}
+  ): Promise<readonly BuildingListElement[]> {
+    if (this.apiBase.getConfiguration().compact || params?.view == "compact") {
       params.view = "compact";
     }
     return this.apiBase
@@ -80,10 +82,11 @@ export default class CartographyApi {
    * @param buildingId The building id to fetch
    * @returns Promise<Building>
    */
-  getBuildingById(buildingId: ID): Promise<Building> {
-    const params: { view?: "compact" } = {};
-
-    if (this.apiBase.getConfiguration().compact) {
+  getBuildingById(
+    buildingId: ID,
+    params: { view?: "compact" } = {}
+  ): Promise<Building> {
+    if (this.apiBase.getConfiguration().compact || params?.view == "compact") {
       params.view = "compact";
     }
     return this.apiBase

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ export default class SitumSDK {
       domain: config.domain || "https://dashboard.situm.com",
       version: SitumSDK.version,
       auth: config.auth,
+      compact: config.compact,
     };
     this.apiBase = new ApiBase(
       this.configuration,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,6 +42,7 @@ export type SDKConfiguration = {
   timeouts?: Record<string, number>;
   version?: string;
   lang?: string;
+  compact?: boolean;
 };
 
 export type SitumSubError = {
@@ -226,7 +227,11 @@ export type Poi = PoiCreateForm & {
   location: Coordinate & Cartesians;
 };
 
-export type PoiSearch = { buildingId?: ID; type?: "indoor" | "outdoor" };
+export type PoiSearch = {
+  buildingId?: ID;
+  type?: "indoor" | "outdoor";
+  view?: "compact";
+};
 
 export type Node = {
   id: number;

--- a/test/domains/cartography_building.test.ts
+++ b/test/domains/cartography_building.test.ts
@@ -58,6 +58,26 @@ describe("SitumSDK.cartography Building", () => {
     axiosMock.mockRestore();
   });
 
+  it("should retrieve all buildings with view=compact", async () => {
+    // Arrange
+    const situmSDK = new SitumSDK({ auth: getMockData("auth"), compact: true });
+    const mockBuildingList = [getMockData("buildingResponseMock1")];
+    const axiosMock = mockAxiosRequest([
+      { access_token: "fakeJWT" },
+      mockBuildingList,
+    ]);
+
+    // Execute
+    const buildingList = await situmSDK.cartography.getBuildings();
+
+    // Assert
+    const configuration = axiosMock.mock.calls[1][0];
+    expect(configuration.params).to.be.equals("view=compact");
+    expect(configuration.url).to.be.equals("/api/v1/buildings");
+    expect(buildingList).is.deep.equal([getMockData("buildingMock1")]);
+    axiosMock.mockClear();
+    axiosMock.mockRestore();
+  });
   it("should create a building", async () => {
     // Arrange
     const mockBuilding = getMockData("buildingMock1");

--- a/test/domains/cartography_poi.test.ts
+++ b/test/domains/cartography_poi.test.ts
@@ -110,6 +110,27 @@ describe("SitumSDK.cartography POI", () => {
     axiosMock.mockRestore();
   });
 
+  it("should retrieve all pois with view=compact", async () => {
+    // Arrange
+    const situmSDK = new SitumSDK({ auth: getMockData("auth"), compact: true });
+    const mockPoi = getMockData("poiMock1");
+    const axiosMock = mockAxiosRequest([
+      { access_token: "fakeJWT" },
+      [getMockData("poiMock1")],
+    ]);
+
+    // Execute
+    const poiList = await situmSDK.cartography.getPois({});
+
+    // Arrange
+    const configuration = axiosMock.mock.calls[1][0];
+    expect(configuration.url).to.be.equals(`/api/v1/pois`);
+    expect(configuration.params).to.be.equals(`view=compact`);
+    expect(poiList).is.deep.equal([getAdapterPoi(mockPoi)]);
+    axiosMock.mockClear();
+    axiosMock.mockRestore();
+  });
+
   it("should create a poi", async () => {
     // Arrange
     const mockPoi = getMockData("poiMock1");


### PR DESCRIPTION
- **What kind of change does this PR introduce?** Feature

- **What is the current behavior?**

This MR introduces a new parameter for the building and pois request to use a simplified view on the server that lowers internet data usage.

- **What is the new behavior (if this is a feature change)?**

This MR adds the `compact: true` parameter on the SDK initialization that will be used in the buildings and POIS request so the response that returns the server will be smaller as it removes unnecessary properties (updated_at, created_at) and normalizes some others (categoryIds instead of list of category full objects)

```
const situmSDK = new SitumSDK({ 
   auth: your_auth_data,
   compact: true 
});
```

- **Have you signed the Situm CLA?**

Yes

- **Other information**:
