### PR TITLE
fix: properly export all public types

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,17 +8,22 @@
 
 export { Viewer } from "../viewer";
 export type { ViewerOptions } from "../viewer/types";
+export { SitumApiPermissionLevel } from "./auth";
 export type {
   Building,
+  BuildingListElement,
   Floor,
   Geofence,
   PathLink,
   PathNode,
   Paths,
   Poi,
+  PoiCategory,
+  PoiCreateForm,
+  PoiUpdateForm,
 } from "./cartography";
 export type { Cartesians, LatLng } from "./coordinates";
-export { ID, UUID } from "./models";
+export { CustomField, ID, Organization, UUID } from "./models";
 export { Route, RouteType } from "./route";
 export { ViewerActionParams, ViewerActionType } from "./webview_api/actions";
 export { ViewerEventPayloads, ViewerEventType } from "./webview_api/events";


### PR DESCRIPTION
### Changed

- Export `SitumApiPermissionLevel`, `BuildingListElement`, `PoiCategory`, `PoiCreateForm`, `PoiUpdateForm`, `CustomField` and `Organization` types
